### PR TITLE
Add all gather matmul

### DIFF
--- a/benchmark/benchmark_all_gather_matmul.py
+++ b/benchmark/benchmark_all_gather_matmul.py
@@ -1,0 +1,284 @@
+import argparse
+import csv
+import functools
+import itertools
+import os
+
+import sys
+from collections import defaultdict
+from dataclasses import asdict, dataclass
+from typing import Optional
+
+import torch
+import torch.distributed as dist
+import torch.distributed._symmetric_memory as symm_mem
+
+from tabulate import tabulate
+
+# Add the kraken directory to the Python path
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import kraken
+from kraken._logging import benchmark_with_event
+
+
+def torch_symm_mem_ag_mm(a_shared, b):
+    a_gathered, c = torch.ops.symm_mem.fused_all_gather_matmul(
+        a_shared, [b], gather_dim=0, group_name=dist.group.WORLD.group_name
+    )
+    return a_gathered, c[0]
+
+
+def nccl_mem_ag_mm(a_shared, b):
+    from torch.distributed._functional_collectives import all_gather_tensor
+
+    a_gathered = all_gather_tensor(a_shared, 0, "0")
+    return a_gathered, torch.matmul(a_gathered, b)
+
+
+@dataclass(frozen=True)
+class ExperimentConfig:
+    shape: tuple[int, int, int]
+    dtype: torch.dtype
+    backends: list[str]
+    baseline_backend: str
+    device: torch.device
+
+    def asdict(self):
+        # Convert the dataclass instance to a dictionary
+        d = asdict(self)
+        d.pop("backends", None)
+        d.pop("device", None)
+        d.pop("baseline_backend", None)
+        return d
+
+
+@dataclass(frozen=True)
+class Experiment:
+    config: ExperimentConfig
+    results: dict[str, float]  # backend -> time in us
+
+    def asdict(self):
+        dict1 = self.config.asdict()
+        dict2 = self.results
+        return {**dict1, **dict2}
+
+
+def generate_experiment_configs(
+    dtype: torch.dtype,
+    M: list[int],
+    N: list[int],
+    K: list[int],
+    backends: list[str],
+    device: torch.device,
+) -> list[ExperimentConfig]:
+    # Generate cross config shapes from M, N, K lists
+    shapes = list(itertools.product(M, N, K))
+
+    all_configs = []
+    for shape in shapes:
+        all_configs.append(
+            ExperimentConfig(
+                shape=shape,
+                dtype=dtype,
+                backends=backends,
+                baseline_backend=backends[0],
+                device=device,
+            )
+        )
+
+    return all_configs
+
+
+def get_single_backend_fn(backend: str):
+    if backend == "nccl":
+        return nccl_mem_ag_mm
+    elif backend == "torch_symm_mem":
+        return torch_symm_mem_ag_mm
+    elif backend == "triton":
+        return kraken.all_gather.triton_all_gather_matmul
+    else:
+        raise NotImplementedError(backend)
+
+
+def clone_symm_mem_tensor(tensor: torch.Tensor) -> torch.Tensor:
+    symm_mem_tensor = symm_mem.empty(
+        tensor.shape,
+        dtype=tensor.dtype,
+        device=tensor.device,
+    )
+    symm_mem.rendezvous(symm_mem_tensor, dist.group.WORLD.group_name)
+    symm_mem_tensor.copy_(tensor)
+    return symm_mem_tensor
+
+
+def run_experiment(config: ExperimentConfig) -> dict[str, float]:
+    M, N, K = config.shape
+    a = symm_mem.empty(
+        (M, K),
+        dtype=config.dtype,
+        device=config.device,
+    ).normal_()
+    b = torch.randn((K, N), device=config.device, dtype=config.dtype).T.contiguous().T
+    symm_mem.rendezvous(a, dist.group.WORLD.group_name)
+
+    input_tensors = {backend: clone_symm_mem_tensor(a) for backend in config.backends}
+    gloden_inp = clone_symm_mem_tensor(a)
+
+    gloden_o = get_single_backend_fn(config.baseline_backend)(gloden_inp, b)
+
+    results = {}
+    for backend in config.backends:
+        fn = get_single_backend_fn(backend)
+        inp = input_tensors[backend]
+
+        test_o = fn(inp, b)
+        torch.testing.assert_close(test_o[1], gloden_o[1], atol=1e-1, rtol=1e-1)
+
+        target_fn = functools.partial(fn, inp, b)
+        results[backend] = benchmark_with_event(target_fn, flush_l2=True)
+
+    return results
+
+
+def print_results(results: list[Experiment], save_path: Optional[str] = None):
+    table_data = defaultdict(list)
+
+    for experiment in results:
+        baseline_time = experiment.results[experiment.config.baseline_backend]
+        min_time = float("inf")
+        best_backend = experiment.config.baseline_backend
+        backends = experiment.config.backends
+        for key, value in experiment.asdict().items():
+            if key in backends:
+                if value < min_time:
+                    min_time = value
+                    best_backend = key
+                table_data[key].append(value)
+            else:
+                table_data[key].append(value)
+        table_data[f"Speedup over {experiment.config.baseline_backend}"].append(
+            baseline_time / min_time
+        )
+        table_data["Best Backend"].append(best_backend)
+    print(tabulate(table_data, headers="keys", tablefmt="github", floatfmt=".3f"))
+
+    if save_path is not None:
+        with open(save_path, "w", newline="") as csvfile:
+            writer = csv.DictWriter(csvfile, fieldnames=table_data.keys())
+            writer.writeheader()
+            for i in range(len(next(iter(table_data.values())))):
+                row = {k: v[i] for k, v in table_data.items()}
+                writer.writerow(row)
+        print(f"\nResults saved to {save_path}")
+
+
+def main(args):
+    device = torch.device(f"cuda:{local_rank}")
+    torch.cuda.set_device(device)
+    dist.init_process_group("nccl")
+    torch.manual_seed(42 + local_rank)
+
+    results = []
+    configs = generate_experiment_configs(
+        args.dtype, args.M, args.N, args.K, args.backend, device
+    )
+    for config in configs:
+        results.append(
+            Experiment(
+                config,
+                run_experiment(config),
+            )
+        )
+    if dist.get_rank() == 0:
+        print_results(results, args.save_path)
+    dist.destroy_process_group()
+
+
+def shape_input_type(s):
+    try:
+        M, N, K = map(int, s.split(","))
+        return M, N, K
+    except Exception as e:
+        raise argparse.ArgumentTypeError("Heads must be Hq,Hkv") from e
+
+
+if __name__ == "__main__":
+    help_str = """
+Run with torchrun
+torchrun \
+--nnodes 1 --nproc-per-node 8 \
+--rdzv-backend c10d --rdzv-endpoint localhost:0 \
+--no_python python3 \
+benchmark/benchmark_all_gather_matmul.py
+"""
+
+    # Set up the argument parser
+    parser = argparse.ArgumentParser(
+        description="Run sweep over sizes for Allreduce. " + help_str
+    )
+
+    parser.add_argument(
+        "--backend",
+        type=str,
+        nargs="+",
+        choices=[
+            "nccl",
+            "torch_symm_mem",
+            "triton",
+        ],
+        default=["nccl", "torch_symm_mem", "triton"],
+        help="Backend to use for AllGather Matmul. Use first backend as baseline. ",
+    )
+
+    parser.add_argument(
+        "-M",
+        type=shape_input_type,
+        nargs="+",
+        default=[2**x for x in range(7, 11)],
+        help="matmul shapes: (M, N, K). (M, K) @ (K, N) -> (M, N)",
+    )
+
+    parser.add_argument(
+        "-N",
+        type=shape_input_type,
+        nargs="+",
+        default=[6656],
+        help="matmul shapes: (M, N, K). (M, K) @ (K, N) -> (M, N)",
+    )
+
+    parser.add_argument(
+        "-K",
+        type=shape_input_type,
+        nargs="+",
+        default=[2**x for x in range(12, 15)],
+        help="matmul shapes: (M, N, K). (M, K) @ (K, N) -> (M, N)",
+    )
+
+    parser.add_argument("-dtype", type=str, help="dtype", default="bfloat16")
+    parser.add_argument(
+        "--save-path",
+        type=str,
+        help="Path to save the results JSON file (optional)",
+        default=None,
+    )
+
+    args = parser.parse_args()
+    args.dtype = getattr(torch, args.dtype)
+
+    if "LOCAL_RANK" not in os.environ:
+        print(
+            "Error: LOCAL_RANK environment variable is not defined. Are you running with torchrun? "
+        )
+        print(help_str)
+        exit(1)
+
+    try:
+        local_rank = int(os.environ["LOCAL_RANK"])
+    except ValueError:
+        print(
+            "Error: LOCAL_RANK environment variable must be a valid integer. Are you running with torchrun? "
+        )
+        print(help_str)
+        exit(1)
+    main(args)

--- a/kraken/__init__.py
+++ b/kraken/__init__.py
@@ -1,4 +1,5 @@
 from . import all_reduce
+from . import all_gather
 from . import _logging
 
-__all__ = ["all_reduce", "_logging"]
+__all__ = ["all_reduce", "all_gather", "_logging"]

--- a/kraken/_ptx_utils/__init__.py
+++ b/kraken/_ptx_utils/__init__.py
@@ -1,4 +1,5 @@
 from .symm_mem_barrier import symm_mem_sync as symm_mem_sync
+from .gmem_barrier_arrive_wait import wait_gmem_barrier, arrive_gmem_barrier
 
-__all__ = ["symm_mem_sync"]
+__all__ = ["symm_mem_sync", "wait_gmem_barrier", "arrive_gmem_barrier"]
 # Avoid ptx_utils when possible

--- a/kraken/_ptx_utils/gmem_barrier_arrive_wait.py
+++ b/kraken/_ptx_utils/gmem_barrier_arrive_wait.py
@@ -1,0 +1,69 @@
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def arrive_gmem_barrier(
+    addr,
+    update: tl.constexpr = 1,  # set the lock value to
+    sem: tl.constexpr = "release",
+    scope: tl.constexpr = "gpu",
+    op: tl.constexpr = "atomic_xchg",
+    skip_sync: tl.constexpr = False,
+):
+    tl.static_assert(
+        op == "atomic_xchg",
+        "Currently only support atomic_xchg wait on gmem_barriers. ",
+    )
+
+    if not skip_sync:
+        tl.inline_asm_elementwise(
+            "bar.sync 0;", "=r", [], dtype=tl.int32, is_pure=False, pack=1
+        )
+    return tl.atomic_xchg(addr, update, sem=sem, scope=scope)
+
+
+@triton.jit
+def wait_gmem_barrier(
+    addr,
+    expect: tl.constexpr = 1,  # wait until lock is set to expect
+    update: tl.constexpr = 0,  # update the lock once it is aquired.
+    sem: tl.constexpr = "acquire",
+    scope: tl.constexpr = "gpu",
+    op: tl.constexpr = "ld",
+    skip_sync: tl.constexpr = False,
+):
+    """
+    Wait for a global memory barrier to reach the expected state.
+
+    This function implements a spin-wait loop that continuously checks a memory location
+    until it reaches the expected value, providing synchronization across GPU threads.
+
+    Args:
+        addr: Memory address of the barrier to wait on (Must be a scalar)
+        expect: Expected value to wait for (default: 1)
+        update: Update the barrier with once acquired (default: 0)
+        sem: Memory semantics for the atomic operation (default: "acquire")
+        scope: Scope of the atomic operation. Options: "gpu", "sys" (default: "gpu")
+        op: Atomic operation type (default: "ld", currently only supported option)
+    """
+    tl.static_assert(
+        op == "ld" and update == 0, "Currently only support ld wait on gmem_barriers. "
+    )
+    # TODO(joydddd): add support for cas barriers.
+
+    tl.static_assert(addr.type.is_ptr(), "Barrier address must be a scalar.")
+    # TODO(joydddd): add wait_gmem_multi_barrier. (each thread waits on a different barrier).
+
+    # Spin-wait loop:
+    #   Uses atomic_add with update=0 for ld.global.{sem}.{scope}
+    #   Triton generates smem broadcasting of tl.atomic_add return value in ptx,
+    #   but it is optimized away by ptxas in SASS, hence no performance overhead.
+    while tl.atomic_add(addr, update, sem=sem, scope=scope) != expect:
+        pass
+
+    if not skip_sync:
+        tl.inline_asm_elementwise(
+            "bar.sync 0;", "=r", [], dtype=tl.int32, is_pure=False, pack=1
+        )
+    # tl.debug_barrier() cause significant performance loss. (Perhaps breaks triton prefetching?)

--- a/kraken/all_gather/__init__.py
+++ b/kraken/all_gather/__init__.py
@@ -1,0 +1,5 @@
+from .triton_all_gather_matmul import (
+    triton_all_gather_matmul as triton_all_gather_matmul,
+)
+
+__all__ = ["triton_all_gather_matmul"]

--- a/kraken/all_gather/copy_engine_all_gather.py
+++ b/kraken/all_gather/copy_engine_all_gather.py
@@ -1,0 +1,50 @@
+import torch
+import torch.distributed as dist
+import torch.distributed._symmetric_memory as symm_mem
+
+
+def copy_engine_all_gather_w_progress(
+    output: torch.Tensor,
+    inp: torch.Tensor,  # Must be symmetric tensor
+    progress: torch.Tensor,
+    splits_per_rank: int,
+    backend_stream: torch.cuda.Stream | None = None,
+) -> torch.cuda.Stream:
+    backend_stream = symm_mem._get_backend_stream(priority=-1)
+    assert inp.is_contiguous()
+
+    symm_mem_hdl = symm_mem.rendezvous(inp, group=dist.group.WORLD)
+    assert symm_mem_hdl is not None
+
+    rank = symm_mem_hdl.rank
+    world_size = symm_mem_hdl.world_size
+
+    assert inp.numel() % splits_per_rank == 0
+    assert progress.numel() >= world_size * splits_per_rank
+
+    output_shape = list(inp.shape)
+    output_shape[0] *= world_size
+    assert list(output.shape) == output_shape, (list(output.shape), output_shape)
+
+    chunks = output.chunk(world_size * splits_per_rank)
+
+    symm_mem_hdl.barrier()
+    backend_stream.wait_stream(torch.cuda.current_stream())
+
+    with torch.cuda.stream(backend_stream):
+        for step in range(0, world_size):
+            src_rank = (rank + step + 1) % world_size
+            for split_id in range(splits_per_rank):
+                src_buf = symm_mem_hdl.get_buffer(
+                    src_rank, chunks[0].shape, inp.dtype, chunks[0].numel() * split_id
+                )
+                chunks[src_rank * splits_per_rank + split_id].copy_(src_buf)
+                # cuStreamWriteValue32 issues a system level fence before the write
+                symm_mem_hdl.stream_write_value32(
+                    progress,
+                    offset=src_rank * splits_per_rank + split_id,
+                    val=1,
+                )
+        symm_mem_hdl.barrier()
+
+    return backend_stream

--- a/kraken/all_gather/triton_all_gather_matmul.py
+++ b/kraken/all_gather/triton_all_gather_matmul.py
@@ -1,0 +1,299 @@
+from typing import Dict, Tuple
+
+import torch
+import torch.distributed as dist
+import torch.distributed._symmetric_memory as symm_mem
+import triton
+import triton.language as tl
+import triton.tools.experimental_descriptor
+
+from .._ptx_utils import wait_gmem_barrier
+
+from .copy_engine_all_gather import copy_engine_all_gather_w_progress
+
+
+def _matmul_launch_metadata(grid, kernel, args):
+    ret = {}
+    M, N, K = args["M"], args["N"], args["K"]
+    ret["name"] = f"{kernel.name} [M={M}, N={N}, K={K}]"
+    ret["flops8"] = 2.0 * M * N * K
+    if "c_ptr" in args:
+        bytes_per_elem = args["c_ptr"].element_size()
+    else:
+        bytes_per_elem = 1 if args["FP8_OUTPUT"] else 2
+    ret["bytes"] = bytes_per_elem * (M * K + N * K)
+    return ret
+
+
+@triton.jit(launch_metadata=_matmul_launch_metadata)
+def _matmul_kernel_tma_persistent_w_progress(
+    a_shared_desc_ptr,
+    a_desc_ptr,
+    b_desc_ptr,
+    c_desc_ptr,
+    progress_ptr,
+    M,
+    N,
+    K,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    COMM_BLOCK_SIZE_M: tl.constexpr,
+    RANK: tl.constexpr,
+    WORLD_SIZE: tl.constexpr,
+    FP8_OUTPUT: tl.constexpr,
+    NUM_SMS: tl.constexpr,
+):
+    """
+    Slightly modified from the sm90 tma persistent Triton tutorial.
+    """
+
+    dtype = tl.float8e4nv if FP8_OUTPUT else tl.bfloat16
+    start_pid = tl.program_id(axis=0)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+    k_tiles = tl.cdiv(K, BLOCK_SIZE_K)
+    num_tiles = num_pid_m * num_pid_n
+
+    tiles_per_SM = num_tiles // NUM_SMS
+    if start_pid < num_tiles % NUM_SMS:
+        tiles_per_SM += 1
+
+    tile_id = start_pid - NUM_SMS
+    ki = -1
+
+    pid_m = 0
+    pid_n = 0
+    offs_am_src = 0
+    offs_bn = 0
+    a_ptr = a_desc_ptr
+
+    num_pid_in_group = GROUP_SIZE_M * num_pid_n
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    for _ in range(0, k_tiles * tiles_per_SM):
+        ki = tl.where(ki == k_tiles - 1, 0, ki + 1)
+        if ki == 0:
+            tile_id += NUM_SMS
+            group_id = tile_id // num_pid_in_group
+            first_pid_m = group_id * GROUP_SIZE_M
+            group_size_m = min(num_pid_m - first_pid_m, GROUP_SIZE_M)
+            pid_m = first_pid_m + (tile_id % group_size_m)
+            pid_n = (tile_id % num_pid_in_group) // group_size_m
+
+            NUM_COMM_BLOCKS = M // COMM_BLOCK_SIZE_M
+            NUM_COMM_BLOCKS_PER_RANK = NUM_COMM_BLOCKS // WORLD_SIZE
+            NUM_PID_M_PER_COMM_BLOCK = COMM_BLOCK_SIZE_M // BLOCK_SIZE_M
+
+            # Pivot tile_id so that M tiles are processed in their ready order.
+            # This pivot preserves the prior swizzling.
+            pid_m = (pid_m + NUM_PID_M_PER_COMM_BLOCK * RANK) % num_pid_m
+
+            comm_block_id = pid_m // NUM_PID_M_PER_COMM_BLOCK
+            if comm_block_id // NUM_COMM_BLOCKS_PER_RANK == RANK:
+                # Read from the local a_shard
+                offs_am_src = (pid_m * BLOCK_SIZE_M) % COMM_BLOCK_SIZE_M
+                a_ptr = a_shared_desc_ptr
+            else:
+                # Wait for and read from a_shard copied from remote ranks
+                wait_gmem_barrier(
+                    progress_ptr + comm_block_id,
+                    expect=1,
+                    sem="acquire",
+                    scope="gpu",
+                    op="ld",
+                )
+                offs_am_src = pid_m * BLOCK_SIZE_M
+                a_ptr = a_desc_ptr
+
+        offs_bn = pid_n * BLOCK_SIZE_N
+        offs_k = ki * BLOCK_SIZE_K
+
+        a = tl._experimental_descriptor_load(
+            a_ptr, [offs_am_src, offs_k], [BLOCK_SIZE_M, BLOCK_SIZE_K], dtype
+        )
+        b = tl._experimental_descriptor_load(
+            b_desc_ptr, [offs_bn, offs_k], [BLOCK_SIZE_N, BLOCK_SIZE_K], dtype
+        )
+        accumulator = tl.dot(a, b.T, accumulator)
+
+        if ki == k_tiles - 1:
+            c = accumulator.to(dtype)
+
+            tl._experimental_descriptor_store(
+                c_desc_ptr, c, [pid_m * BLOCK_SIZE_M, offs_bn]
+            )
+            accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+
+_tma_desc_cache = {}
+
+
+def _create_2d_tma_descriptor(ptr, dim1, dim0, block_dim1, block_dim0, element_size):
+    global _tma_desc_cache
+    key = (ptr, dim1, dim0, block_dim1, block_dim0, element_size)
+    if key in _tma_desc_cache:
+        return _tma_desc_cache[key]
+    desc = triton.tools.experimental_descriptor.create_2d_tma_descriptor(
+        ptr,
+        dim1,
+        dim0,
+        block_dim1,
+        block_dim0,
+        element_size,
+    )
+    _tma_desc_cache[key] = desc
+    return desc
+
+
+def _matmul_w_progress(
+    a: torch.Tensor,
+    a_shared: torch.Tensor,
+    b: torch.Tensor,
+    progress: torch.Tensor,
+    configs: Dict,
+) -> torch.Tensor:
+    M, K = a.shape
+    K2, N = b.shape
+    assert K2 == K
+
+    bT = b.T
+
+    c = torch.empty((M, N), device=a.device, dtype=a.dtype)
+
+    desc_a_shared = _create_2d_tma_descriptor(
+        a_shared.data_ptr(),
+        a_shared.shape[0],
+        K,
+        configs["BLOCK_SIZE_M"],
+        configs["BLOCK_SIZE_K"],
+        a_shared.element_size(),
+    )
+
+    desc_a = _create_2d_tma_descriptor(
+        a.data_ptr(),
+        M,
+        K,
+        configs["BLOCK_SIZE_M"],
+        configs["BLOCK_SIZE_K"],
+        a.element_size(),
+    )
+    desc_bt = _create_2d_tma_descriptor(
+        bT.data_ptr(),
+        N,
+        K,
+        configs["BLOCK_SIZE_N"],
+        configs["BLOCK_SIZE_K"],
+        b.element_size(),
+    )
+    desc_c = _create_2d_tma_descriptor(
+        c.data_ptr(),
+        M,
+        N,
+        configs["BLOCK_SIZE_M"],
+        configs["BLOCK_SIZE_N"],
+        c.element_size(),
+    )
+
+    configs["NUM_SMS"] = torch.cuda.get_device_properties(
+        a.device
+    ).multi_processor_count
+
+    grid = lambda META: (  # noqa: E731
+        min(
+            configs["NUM_SMS"],
+            triton.cdiv(M, META["BLOCK_SIZE_M"]) * triton.cdiv(N, META["BLOCK_SIZE_N"]),
+        ),
+    )
+
+    _matmul_kernel_tma_persistent_w_progress[grid](
+        desc_a_shared,
+        desc_a,
+        desc_bt,
+        desc_c,
+        progress,
+        M,
+        N,
+        K,
+        BLOCK_SIZE_M=configs["BLOCK_SIZE_M"],
+        BLOCK_SIZE_N=configs["BLOCK_SIZE_N"],
+        BLOCK_SIZE_K=configs["BLOCK_SIZE_K"],
+        GROUP_SIZE_M=configs["GROUP_SIZE_M"],
+        COMM_BLOCK_SIZE_M=configs["COMM_BLOCK_SIZE_M"],
+        RANK=configs["RANK"],
+        WORLD_SIZE=configs["WORLD_SIZE"],
+        FP8_OUTPUT=a.dtype == torch.float8_e4m3fn,
+        NUM_SMS=configs["NUM_SMS"],
+        num_stages=configs["num_stages"],
+        num_warps=configs["num_warps"],
+    )
+
+    return c
+
+
+def triton_all_gather_matmul(
+    a_shared: torch.Tensor,
+    b: torch.Tensor,
+    a_out: torch.Tensor | None = None,
+    progress: torch.Tensor | None = None,
+    **kwargs,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    configs = {
+        "SPLITS_PER_RANK": kwargs.get("splits_per_rank", 1),
+        "BLOCK_SIZE_M": kwargs.get("block_size_m", 128),
+        "BLOCK_SIZE_N": kwargs.get("block_size_n", 256),
+        "BLOCK_SIZE_K": kwargs.get("block_size_k", 64),
+        "GROUP_SIZE_M": kwargs.get("group_size_m", 4),
+        "num_stages": kwargs.get("num_stages", 3),
+        "num_warps": kwargs.get("num_warps", 8),
+    }
+
+    symm_mem_hdl = symm_mem.rendezvous(a_shared, group=dist.group.WORLD)
+
+    a_shape = list(a_shared.shape)
+    a_shape[0] *= symm_mem_hdl.world_size
+
+    configs["RANK"] = symm_mem_hdl.rank
+    configs["WORLD_SIZE"] = symm_mem_hdl.world_size
+    if (
+        configs["SPLITS_PER_RANK"]
+        * configs["WORLD_SIZE"]
+        * configs["BLOCK_SIZE_M"]
+        * configs["GROUP_SIZE_M"]
+        > a_shape[0]
+    ):
+        configs["GROUP_SIZE_M"] = 1
+        configs["SPLITS_PER_RANK"] = 1
+
+    configs["COMM_BLOCK_SIZE_M"] = (
+        a_shape[0] // configs["WORLD_SIZE"] // configs["SPLITS_PER_RANK"]
+    )
+    assert (
+        configs["COMM_BLOCK_SIZE_M"]
+        % (configs["BLOCK_SIZE_M"] * configs["GROUP_SIZE_M"])
+        == 0
+    )
+
+    if a_out is None:
+        a_out = torch.empty(a_shape, dtype=a_shared.dtype, device=a_shared.device)
+
+    if progress is None:
+        progress = torch.zeros(
+            symm_mem_hdl.world_size * configs["SPLITS_PER_RANK"],
+            dtype=torch.uint32,
+            device=a_shared.device,
+        )
+    else:
+        progress.fill_(0)  # Reset progress to 0.
+
+    backend_stream = copy_engine_all_gather_w_progress(
+        a_out, a_shared, progress, configs["SPLITS_PER_RANK"]
+    )
+
+    c = _matmul_w_progress(a_out, a_shared, b, progress, configs)
+
+    torch.cuda.current_stream().wait_stream(backend_stream)
+
+    return a_out, c

--- a/test/test_allgather_matmul.py
+++ b/test/test_allgather_matmul.py
@@ -1,0 +1,83 @@
+import torch
+import torch.distributed as dist
+import torch.distributed._symmetric_memory as symm_mem
+
+from torch.testing._internal.common_distributed import (
+    MultiProcessTestCase,
+    skip_if_lt_x_gpu,
+)
+
+from torch.testing._internal.common_utils import (
+    instantiate_parametrized_tests,
+    run_tests,
+)
+
+import sys
+import os
+
+# Add the parent directory to the Python path
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import kraken
+
+
+@instantiate_parametrized_tests
+class TritonAllGatherMatmulTest(MultiProcessTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self._spawn_processes()
+
+    @property
+    def world_size(self) -> int:
+        # world_size > 2 is needed to verify accumulation order
+        return 4
+
+    @property
+    def device(self) -> torch.device:
+        return torch.device(f"cuda:{self.rank}")
+
+    def _init_process(self):
+        torch.cuda.set_device(self.device)
+        store = dist.FileStore(self.file_name, self.world_size)
+        dist.init_process_group(
+            backend="nccl",
+            world_size=self.world_size,
+            rank=self.rank,
+            store=store,
+        )
+        torch.manual_seed(42 + self.rank)
+
+    @skip_if_lt_x_gpu(4)
+    def test_triton_all_gather_matmul(self):
+        self._init_process()
+        M = 4096
+        N = 6656
+        K = 16384
+
+        group_name = dist.group.WORLD.group_name
+        a_shared = symm_mem.empty(
+            (M // self.world_size, K),
+            dtype=torch.bfloat16,
+            device=self.device,
+        ).normal_()
+        symm_mem.rendezvous(a_shared, group_name)
+        bT = torch.randn(
+            (K, N), device=self.device, dtype=torch.bfloat16
+        ).T.contiguous()
+        b = bT.T
+
+        ag, c = kraken.all_gather.triton_all_gather_matmul(a_shared, b)
+
+        golden_a = a_shared.clone()
+        ag_golden, mm_golden = torch.ops.symm_mem.fused_all_gather_matmul(
+            golden_a, [b], gather_dim=0, group_name=group_name
+        )
+
+        torch.testing.assert_close(c, mm_golden[0], rtol=1e-1, atol=1e-1)
+        torch.testing.assert_close(ag, ag_golden)
+
+        dist.destroy_process_group()
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/test/test_ptx_utils.py
+++ b/test/test_ptx_utils.py
@@ -10,6 +10,7 @@ from torch.testing._internal.common_distributed import (
 from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
     run_tests,
+    TestCase,
 )
 
 import sys
@@ -22,7 +23,7 @@ sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 import triton
 import triton.language as tl
 
-from kraken._ptx_utils import symm_mem_sync
+from kraken._ptx_utils import symm_mem_sync, wait_gmem_barrier, arrive_gmem_barrier
 
 
 @instantiate_parametrized_tests
@@ -60,7 +61,7 @@ class PTXSymmMemBarrier(MultiProcessTestCase):
         symm_mem_sync(signal_pad_ptrs, None, rank, world_size)
 
     @skip_if_lt_x_gpu(4)
-    def test_blockwise_barrier(self):
+    def test_symm_mem_barrier(self):
         self._init_process()
         t = symm_mem.empty(4096, device=self.device)
         symm_mem_hdl = symm_mem.rendezvous(t, group=dist.group.WORLD)
@@ -75,6 +76,51 @@ class PTXSymmMemBarrier(MultiProcessTestCase):
         assert signal_pad.eq(0).all().item()
 
         dist.destroy_process_group()
+
+
+class PTXGmemBarrier(TestCase):
+    @triton.jit
+    def gmem_barrier_test_kernel(
+        signal_pad_ptrs,
+        NUM_PRODUCERS: tl.constexpr,
+        NUM_CONSUMERS: tl.constexpr,
+    ):
+        bid = tl.program_id(0)
+        if bid < NUM_PRODUCERS:
+            arrive_gmem_barrier(
+                signal_pad_ptrs + bid,
+                update=1,
+                sem="release",
+                scope="gpu",
+                op="atomic_xchg",
+            )
+            pass
+        else:
+            consumer_id = bid - NUM_PRODUCERS
+            producer_id = consumer_id // (NUM_CONSUMERS // NUM_PRODUCERS)
+            wait_gmem_barrier(
+                signal_pad_ptrs + producer_id,
+                expect=1,
+                sem="acquire",
+                scope="gpu",
+                op="ld",
+            )
+
+    def test_gmem_barrier_arrive_wait(self):
+        signal_pad = torch.zeros(64, device="cuda", dtype=torch.int32).contiguous()
+        num_producers = 8
+        num_consumers = 32
+
+        self.gmem_barrier_test_kernel[(num_producers + num_consumers, 1, 1)](
+            signal_pad,
+            NUM_PRODUCERS=num_producers,
+            NUM_CONSUMERS=num_consumers,
+        )
+
+        expect = torch.zeros_like(signal_pad)
+        expect[:num_producers] = 1
+
+        torch.testing.assert_close(signal_pad, expect)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### 8xH100


| shape               | dtype          |     nccl |   torch_symm_mem |   triton |   Speedup over nccl | Best Backend   |
|---------------------|----------------|----------|------------------|----------|---------------------|----------------|
| (128, 6656, 4096)   | torch.bfloat16 |  141.984 |          277.184 |  194.624 |               1.000 | nccl           |
| (128, 6656, 8192)   | torch.bfloat16 |  284.288 |          635.072 |  395.040 |               1.000 | nccl           |
| (128, 6656, 16384)  | torch.bfloat16 |  513.600 |         1166.944 |  849.024 |               1.000 | nccl           |
| (256, 6656, 4096)   | torch.bfloat16 |  272.992 |          309.920 |  282.752 |               1.000 | nccl           |
| (256, 6656, 8192)   | torch.bfloat16 |  499.392 |          548.480 |  553.088 |               1.000 | nccl           |
| (256, 6656, 16384)  | torch.bfloat16 |  953.216 |         1333.120 | 1217.248 |               1.000 | nccl           |
| (512, 6656, 4096)   | torch.bfloat16 |  514.496 |          455.776 |  455.296 |               1.130 | triton         |
| (512, 6656, 8192)   | torch.bfloat16 |  912.384 |          837.792 |  810.368 |               1.126 | triton         |
| (512, 6656, 16384)  | torch.bfloat16 | 1810.432 |         1633.312 | 1679.776 |               1.108 | torch_symm_mem |
| (1024, 6656, 4096)  | torch.bfloat16 |  935.680 |          835.168 |  839.648 |               1.120 | torch_symm_mem |
| (1024, 6656, 8192)  | torch.bfloat16 | 1788.288 |         1902.784 | 1969.824 |               1.000 | nccl           |
| (1024, 6656, 16384) | torch.bfloat16 | 5945.344 |         5159.456 | 5964.640 |               1.152 | torch_symm_mem |